### PR TITLE
Bump Dockerfiles go version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Compile stage
-FROM golang:1.17 AS build-env
+FROM golang:1.18 AS build-env
 
 # Build Delve
 RUN go install github.com/go-delve/delve/cmd/dlv@latest


### PR DESCRIPTION
bump go as was causing the following issue, container crashing

<img width="1166" alt="Screenshot 2023-08-21 at 00 44 58" src="https://github.com/asspirin12/dockerdev/assets/8657653/6a6693ba-7d55-41dc-ba10-c4d6377788c4">
